### PR TITLE
Use two tests driver files

### DIFF
--- a/tester_flat.lgt
+++ b/tester_flat.lgt
@@ -1,0 +1,24 @@
+:- if(current_logtalk_flag(prolog_dialect, swi)).
+	:- initialization((
+		set_logtalk_flag(report, warnings),
+		use_module(library(dicts)),
+		logtalk_load([
+			meta(loader),
+			dictionaries(loader),
+			nested_dictionaries(loader)
+		]),
+		logtalk_load(lgtunit(loader)),
+		logtalk_load([
+			swidict
+		], [
+			source_data(on),
+			debug(on)
+		]),
+		logtalk_load([dictionaries(tests)], [hook(lgtunit)]),
+		tests(swidict)::run
+	)).
+:- else.
+	:- initialization((
+		write('SWI-Prolog Backend required to use SWI-Prolog Dictionaries'), nl
+	)).
+:- endif.

--- a/tester_nested.lgt
+++ b/tester_nested.lgt
@@ -15,11 +15,8 @@
 			source_data(on),
 			debug(on)
 		]),
-		logtalk_load([dictionaries(tests)], [hook(lgtunit)]),
-		tests(swidict)::run,
-		/*logtalk_load(nested_dictionaries(tests), [hook(lgtunit)]),*/
-		/*tests(nswidict)::run,*/
-		true
+		logtalk_load(nested_dictionaries(tests), [hook(lgtunit)]),
+		tests(nswidict)::run
 	)).
 :- else.
 	:- initialization((


### PR DESCRIPTION
For automated testing, use:

```bash
$ logtalk_tester -p swi -n tester_flat
...
$ logtalk_tester -p swi -n tester_nested
```
